### PR TITLE
Add radius flag to read_xray to isolate circular detector area

### DIFF
--- a/src/xvr/io/xray.py
+++ b/src/xvr/io/xray.py
@@ -17,6 +17,7 @@ def read_xray(
     subtract_background: bool = False,
     linearize: bool = True,
     reducefn: str | int | Callable = "max",
+    radius: float | None = None,
 ) -> tuple[Float[torch.Tensor, "1 1 H W"], Intrinsics, bool]:
     """Read and preprocess an X-ray image from a DICOM file.
 
@@ -39,6 +40,9 @@ def read_xray(
             - ``int``: index of the frame to extract.
             - ``Callable``: arbitrary function applied to the 5D tensor.
             - ``None``: no reduction; tensor remains 5D.
+        radius: If given, treat the detector as circular with this radius (in
+            pixels), centered on the image. Pixels outside the circle are set
+            to the minimum intensity of the processed image.
 
     Returns:
         img: Preprocessed image tensor of shape ``(1, 1, H, W)``.
@@ -61,6 +65,10 @@ def read_xray(
     # Reduce a temporal dimension
     if img.ndim == 5:
         img = _reduce_frames(img, reducefn)
+
+    # Isolate the circular detector area
+    if radius is not None:
+        img = _mask_outside_circle(img, radius)
 
     return img, intrinsics, pf_to_af
 
@@ -91,6 +99,19 @@ def _parse_dicom_intrinsics(ds) -> tuple[Intrinsics, bool]:
         pass
 
     return Intrinsics(sdd, delx, dely, x0, y0), pf_to_af
+
+
+def _mask_outside_circle(img: torch.Tensor, radius: float) -> torch.Tensor:
+    """Set pixels outside a centered circle of the given radius to the image minimum."""
+    *_, height, width = img.shape
+    cy, cx = (height - 1) / 2, (width - 1) / 2
+    yy, xx = torch.meshgrid(
+        torch.arange(height, device=img.device),
+        torch.arange(width, device=img.device),
+        indexing="ij",
+    )
+    outside = (yy - cy) ** 2 + (xx - cx) ** 2 > radius**2
+    return torch.where(outside, img.min(), img)
 
 
 def _reduce_frames(img: torch.Tensor, reducefn: str | int | Callable | None) -> torch.Tensor:


### PR DESCRIPTION
# Add radius flag to read_xray to isolate circular detector area

Closes #59.

## What

Adds an optional keyword argument to `read_xray()`:

```python
img, intrinsics, pf_to_af = read_xray(path, radius=20.0)
```

- `radius: float | None = None` — if given, the detector is treated as circular with this radius **in pixels**, centered on the image.
- Pixels outside the circle are set to the minimum intensity of the processed image (per #59: "sets its value to the min").
- Masking runs **after** temporal reduction, so the guarantee holds on the final image regardless of `reducefn` (e.g., with `reducefn="sum"` masking first would leave outside pixels at `N × min`).
- Implemented as a small pure helper `_mask_outside_circle()`; appended as the last parameter so existing positional callers (e.g., `register.py`) stay source-compatible.

## Verification

Tested with a scratch suite (happy to move into a proper test dir if the project wants tests upstream):

1. **Unit (geometry)**: random 32×32 image, `radius=10` → masked fraction matches `1 − πr²/(H·W)` within tolerance; center pixel preserved; corners equal min.
2. **End-to-end**: wrote a synthetic DICOM (pydicom, ExplicitVRLittleEndian with required tags), then:
   - `read_xray(p)` vs `read_xray(p, radius=20)`
   - every outside-circle pixel equals the image min;
   - inside-circle pixels are **bit-identical** to the no-radius run.

## Possible follow-up

Wire `radius` through `RegistrationResult.register()` so circular-detector C-arm data flows straight into registration. Kept out of this PR to keep the diff focused — say the word and I'll send it.
